### PR TITLE
fix: add CORS configuration to server

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+PORT=3001
+FRONTEND_URL=http://localhost:3000

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const cors = require('cors');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+
+// Configuration CORS
+const corsOptions = {
+  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  credentials: true,
+  optionsSuccessStatus: 200
+};
+
+app.use(cors(corsOptions));
+app.use(express.json());
+
+// Routes
+app.use('/api/jobs', require('./routes/jobs'));
+
+const PORT = process.env.PORT || 3001;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "job-search-france-travail-api-server",
+  "version": "1.0.0",
+  "description": "Backend server for France Travail job search API",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "dotenv": "^16.4.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+
+router.post('/search', async (req, res) => {
+  try {
+    // Logique de recherche à implémenter
+    res.json({ message: 'Recherche en cours de développement' });
+  } catch (error) {
+    console.error('Erreur lors de la recherche:', error);
+    res.status(500).json({ error: 'Erreur serveur lors de la recherche' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Cette PR ajoute la configuration CORS nécessaire au serveur pour résoudre les erreurs de CORS lors des appels API.

Changes apportés :

1. Configuration du serveur Express avec CORS :
   - Ajout du package cors
   - Configuration des options CORS pour autoriser les requêtes depuis le frontend
   - Support des méthodes HTTP nécessaires
   - Gestion des headers autorisés

2. Structure du serveur :
   - Configuration avec dotenv pour la gestion des variables d'environnement
   - Route de base pour l'API de recherche d'emplois
   - Exemple de fichier .env pour la configuration

Pour utiliser ces changements :

1. Copier .env.example vers .env dans le dossier server
2. Installer les dépendances :
   ```bash
   cd server
   npm install
   ```
3. Démarrer le serveur :
   ```bash
   npm run dev
   ```

Le serveur écoutera par défaut sur le port 3001 et acceptera les requêtes depuis http://localhost:3000